### PR TITLE
[Fix] ConversionService 乱匹配空字段问题

### DIFF
--- a/build_scripts/build_setups.gradle
+++ b/build_scripts/build_setups.gradle
@@ -1,5 +1,5 @@
 ext {
-  publishVersion = '1.2.29'
+  publishVersion = '1.2.31-SNAPSHOT'
 }
 
 apply plugin: 'java'

--- a/build_scripts/build_setups.gradle
+++ b/build_scripts/build_setups.gradle
@@ -1,5 +1,5 @@
 ext {
-  publishVersion = '1.2.31-SNAPSHOT'
+  publishVersion = '1.2.31'
 }
 
 apply plugin: 'java'

--- a/src/main/java/com/tehang/common/utility/modelconversion/ModelConversionService.java
+++ b/src/main/java/com/tehang/common/utility/modelconversion/ModelConversionService.java
@@ -3,8 +3,11 @@ package com.tehang.common.utility.modelconversion;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.Converter;
 import org.modelmapper.ModelMapper;
+import org.modelmapper.convention.MatchingStrategies;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
 
 /**
  * 进行 Model 转换 能够自动对同名属性进行映射（更多实现细节查看 http://modelmapper.org） 如果有特殊的转换需求，通过自定义 `AutoRegisterModelConverter` 以实现
@@ -14,6 +17,11 @@ import org.springframework.stereotype.Service;
 public class ModelConversionService {
 
   private final ModelMapper modelMapper = new ModelMapper();
+
+  @PostConstruct
+  void init() {
+    this.modelMapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
+  }
 
   /**
    * convert.


### PR DESCRIPTION
ModelMapper 默认的策略配置会出现将 policyId 匹配到 id 上的情况，它会尽可能避免 bean 中出现空。
我们想要的是精确的匹配，所以换成 `Strict` 策略。

Matching Strategies:
http://modelmapper.org/user-manual/configuration/#matching-strategies

![image](https://user-images.githubusercontent.com/1916880/132617040-4848fdc3-7656-42ed-8433-723f0855227c.png)

![image](https://user-images.githubusercontent.com/1916880/132616906-a980a673-071b-4eb3-9140-0ba7ed8d4e83.png)
